### PR TITLE
reorganize to use an internal mpsc event queue & processing thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+Unreleased
+==========
+
+* Changed from connection per thread to a single connection and a message queue
+  serviced by a dedicated ingest thread.
+* Tracing from tokio is now supported.
+* Replaced use of `tracing-serde*` crates with internal types.
+
+Version 0.1.0
+=============
+
+Initial Release

--- a/tracing-modality/Cargo.toml
+++ b/tracing-modality/Cargo.toml
@@ -3,22 +3,26 @@ name = "tracing-modality"
 version = "0.1.0"
 edition = "2021"
 description = "This crate provides a `tracing` `Layer` (and `Subscriber`) for emitting trace data to Auxon Modality"
-repository = "https://github.com/auxon/modality-tracing-rs"
+repository = "https://github.com/auxoncorp/modality-tracing-rs"
 license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+dirs = "4"
+hex = "0.4"
+modality-ingest-client = "0.1"
+once_cell = "1"
 serde_json = "1"
 thiserror = "1"
-tokio = "1"
+tokio = { version = "1", features = ["rt", "net", "sync"] }
 tracing = "0.1"
-tracing-core = "0.1.27"
-tracing-serde-modality-ingest = { version = "0.1", path = "../tracing-serde-modality-ingest" }
-tracing-serde-subscriber = { version = "0.1", path = "../tracing-serde-subscriber" }
+tracing-core = "0.1"
+tracing-subscriber = "0.3"
+url = "2"
+uuid = { version = "1", features = ["v4"] }
+
 
 [dev-dependencies]
 # used for some examples
 rand = { version = "0.8.5" }
 ctrlc = "3.2.2"
-# used for pipeline example
-tracing-subscriber = "0.3"

--- a/tracing-modality/README.md
+++ b/tracing-modality/README.md
@@ -10,20 +10,28 @@ The quickest (and as of this version, only) way to get started is to let
 [`TracingModality`] register itself as the global default tracer, done most
 simply using [`TracingModality::init()`]
 
-```rust
+```rust,no_run
 use tracing::debug;
 use tracing_modality::TracingModality;
 use tracing::info;
 
 fn main() {
-    TracingModality::init().expect("init");
+    // first thing in main
+    let mut modality = TracingModality::init().expect("init");
 
     info!("my application has started");
+
+    // last thing in main
+    modality.finish()
 }
 ```
 
 Some basic configuration options are also available to be set at init with
 [`TracingModality::init_with_options`].
+
+As this example shows, you must [`TracingModality::finish`] at the end of your
+main thread to ensure the ingest thread handing all trace events has a chance to
+finish flushing all queued events before your program exits.
 
 ## Usage
 

--- a/tracing-modality/examples/basic.rs
+++ b/tracing-modality/examples/basic.rs
@@ -2,16 +2,20 @@ use tracing::{debug, error, event, info, span, trace, warn, Level};
 use tracing_modality::{Options, TracingModality};
 
 fn main() {
-    TracingModality::init_with_options(
+    let modality = TracingModality::init_with_options(
         Options::new()
             .with_name("basic example")
             .with_metadata("build_id", 0i64),
     )
     .expect("init tracing");
 
-    let span = span!(Level::TRACE, "outer_span");
-    let _span = span.enter();
-    do_thing::doit();
+    {
+        let span = span!(Level::TRACE, "outer_span");
+        let _span = span.enter();
+        do_thing::doit();
+    }
+
+    modality.finish();
 }
 
 pub mod do_thing {

--- a/tracing-modality/examples/monitored_pipeline.rs
+++ b/tracing-modality/examples/monitored_pipeline.rs
@@ -12,9 +12,12 @@ use tracing_subscriber::{fmt::Layer, layer::SubscriberExt, Registry};
 
 fn main() {
     // setup custom tracer including ModalityLayer
-    {
-        let modality_layer = ModalityLayer::new();
-        modality_layer.connect_or_panic();
+    let modality = {
+        let mut modality_layer = ModalityLayer::init().expect("initialize ModalityLayer");
+
+        let modality_ingest_handle = modality_layer
+            .take_handle()
+            .expect("handle exists on new layer");
 
         let subscriber = Registry::default()
             .with(modality_layer)
@@ -22,7 +25,9 @@ fn main() {
 
         let disp = Dispatch::new(subscriber);
         tracing::dispatcher::set_global_default(disp).expect("set global tracer");
-    }
+
+        modality_ingest_handle
+    };
 
     // Enable signal handling for convenient process termination.
     let shutdown_requested = Arc::new(AtomicBool::new(false));
@@ -110,6 +115,8 @@ fn main() {
             tracing::info!(component = component.name(), "Joined thread");
         }
     }
+
+    modality.finish();
 }
 
 const CONSUMER_CHANNEL_SIZE: usize = 64;

--- a/tracing-modality/examples/simple_multi.rs
+++ b/tracing-modality/examples/simple_multi.rs
@@ -17,7 +17,7 @@ struct Job {
 }
 
 fn main() {
-    TracingModality::init().expect("init tracing");
+    let modality = TracingModality::init().expect("init tracing");
     let mut rng = thread_rng();
 
     let (terminal_tx, terminal_rx): (Sender<Message>, Receiver<Message>) = channel();
@@ -116,4 +116,7 @@ fn main() {
     for t in threads {
         t.join().unwrap();
     }
+
+    // end the modality ingest thread, flushing all already written events to modality
+    modality.finish();
 }

--- a/tracing-modality/src/ingest.rs
+++ b/tracing-modality/src/ingest.rs
@@ -1,0 +1,672 @@
+pub use modality_ingest_client::types::TimelineId;
+
+use crate::layer::{RecordMap, TracingValue};
+use crate::Options;
+use anyhow::Context;
+use modality_ingest_client::{
+    client::{BoundTimelineState, IngestClient},
+    types::{AttrKey, AttrVal, BigInt, LogicalTime, Nanoseconds, Uuid},
+    IngestError as SdkIngestError,
+};
+use once_cell::sync::Lazy;
+use std::{
+    collections::HashMap,
+    num::NonZeroU64,
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+use thiserror::Error;
+use tokio::{
+    runtime::Runtime,
+    select,
+    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    sync::oneshot,
+};
+use tracing_core::Metadata;
+
+thread_local! {
+    static THREAD_TIMELINE_ID: Lazy<TimelineId> = Lazy::new(TimelineId::allocate);
+}
+
+#[derive(Debug, Error)]
+pub enum ConnectError {
+    /// No auth was provided
+    #[error("Authentication required")]
+    AuthRequired,
+    /// Auth was provided, but was not accepted by modality
+    #[error("Authenticating with the provided auth failed")]
+    AuthFailed(SdkIngestError),
+    /// Errors that it is assumed there is no way to handle without human intervention, meant for
+    /// consumers to just print and carry on or panic.
+    #[error(transparent)]
+    UnexpectedFailure(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum IngestError {
+    /// Errors that it is assumed there is no way to handle without human intervention, meant for
+    /// consumers to just print and carry on or panic.
+    #[error(transparent)]
+    UnexpectedFailure(#[from] anyhow::Error),
+}
+
+pub(crate) fn current_timeline() -> TimelineId {
+    THREAD_TIMELINE_ID.with(|id| **id)
+}
+
+pub(crate) type SpanId = NonZeroU64;
+
+#[derive(Debug)]
+pub(crate) struct WrappedMessage {
+    pub message: Message,
+    pub tick: Duration,
+    pub timeline: TimelineId,
+}
+
+#[derive(Debug)]
+pub(crate) enum Message {
+    NewTimeline {
+        name: String,
+    },
+    NewSpan {
+        id: SpanId,
+        metadata: &'static Metadata<'static>,
+        records: RecordMap,
+    },
+    Record {
+        span: SpanId,
+        records: RecordMap,
+    },
+    RecordFollowsFrom {
+        span: SpanId,
+        follows: SpanId,
+    },
+    Event {
+        metadata: &'static Metadata<'static>,
+        records: RecordMap,
+    },
+    Enter {
+        span: SpanId,
+    },
+    Exit {
+        span: SpanId,
+    },
+    Close {
+        span: SpanId,
+    },
+    IdChange {
+        old: SpanId,
+        new: SpanId,
+    },
+}
+
+pub struct ModalityIngestHandle {
+    pub(crate) ingest_sender: UnboundedSender<WrappedMessage>,
+    pub(crate) thread: Option<JoinHandle<()>>,
+    pub(crate) finish_sender: Option<oneshot::Sender<()>>,
+}
+
+impl ModalityIngestHandle {
+    /// Stop accepting new trace events, flush all existing events, and stop ingest thread.
+    ///
+    /// This function must be called at the end of your main thread to give the ingest thread a
+    /// chance to flush all queued trace events out to modality.
+    ///
+    /// # Panics
+    ///
+    /// This function uses [`std::thread::join`] which may panic on some platforms if a thread
+    /// attempts to join itself or otherwise may create a deadlock with joining threads. This case
+    /// should be incredibly unlikely, if not impossible, but can not be statically guarenteed.
+    pub fn finish(mut self) {
+        if let Some(finish) = self.finish_sender.take() {
+            let _ = finish.send(());
+        }
+
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+pub(crate) struct ModalityIngest {
+    client: IngestClient<BoundTimelineState>,
+    global_metadata: Vec<(String, AttrVal)>,
+    event_keys: HashMap<String, AttrKey>,
+    timeline_keys: HashMap<String, AttrKey>,
+    span_names: HashMap<NonZeroU64, String>,
+    rt: Option<Runtime>,
+}
+
+impl ModalityIngest {
+    pub(crate) fn connect(opts: Options) -> Result<Self, ConnectError> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .expect("build intial tokio current thread runtime");
+
+        rt.block_on(async { Self::async_connect(opts).await })
+            .map(move |mut m| {
+                m.rt = Some(rt);
+                m
+            })
+    }
+
+    pub(crate) async fn async_connect(options: Options) -> Result<Self, ConnectError> {
+        let url = url::Url::parse(&format!("modality-ingest://{}/", options.server_addr)).unwrap();
+        let unauth_client = IngestClient::connect(&url, false)
+            .await
+            .context("init ingest client")?;
+
+        let auth_key = options.auth.ok_or(ConnectError::AuthRequired)?;
+        let client = unauth_client
+            .authenticate(auth_key)
+            .await
+            .map_err(ConnectError::AuthFailed)?;
+
+        // open a timeline for the current thread because we need to open something to make the
+        // types work
+        let timeline_id = current_timeline();
+        let client = client
+            .open_timeline(timeline_id)
+            .await
+            .context("open new timeline")?;
+
+        Ok(Self {
+            client,
+            global_metadata: options.metadata,
+            event_keys: HashMap::new(),
+            timeline_keys: HashMap::new(),
+            span_names: HashMap::new(),
+            rt: None,
+        })
+    }
+
+    pub(crate) fn spawn_thread(mut self) -> ModalityIngestHandle {
+        let (sender, recv) = mpsc::unbounded_channel();
+        let (finish_sender, finish_receiver) = oneshot::channel();
+
+        let join_handle = thread::spawn(move || {
+            // ensure this thread doesn't send trace events to the global dispatcher
+            let _dispatch_guard = tracing::dispatcher::set_default(&tracing::Dispatch::none());
+
+            let rt = self.rt.take().unwrap_or_else(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .expect("build local tokio current thread runtime")
+            });
+
+            rt.block_on(self.handler_task(recv, finish_receiver))
+        });
+
+        ModalityIngestHandle {
+            ingest_sender: sender,
+            thread: Some(join_handle),
+            finish_sender: Some(finish_sender),
+        }
+    }
+
+    async fn handler_task(
+        mut self,
+        mut recv: UnboundedReceiver<WrappedMessage>,
+        mut finish: oneshot::Receiver<()>,
+    ) {
+        loop {
+            select! {
+                Some(message) = recv.recv() => {
+                    let _ = self.handle_packet(message).await;
+                },
+                _ = &mut finish => {
+                    break
+                }
+            }
+        }
+
+        // close channel and drain existing messages
+        recv.close();
+        while let Some(message) = recv.recv().await {
+            let _ = self.handle_packet(message).await;
+        }
+    }
+
+    async fn handle_packet(&mut self, message: WrappedMessage) -> Result<(), IngestError> {
+        let WrappedMessage {
+            message,
+            tick,
+            timeline,
+        } = message;
+
+        if self.client.bound_timeline() != timeline {
+            self.client
+                .open_timeline(timeline)
+                .await
+                .context("open new timeline")?;
+        }
+
+        match message {
+            Message::NewTimeline { name } => {
+                let mut timeline_metadata = self.global_metadata.clone();
+
+                if !timeline_metadata.iter().any(|(k, _v)| k == "name") {
+                    timeline_metadata.push(("timeline.name".to_string(), name.into()));
+                }
+
+                for (key, value) in timeline_metadata {
+                    let timeline_key_name = self
+                        .get_or_create_timeline_attr_key(key)
+                        .await
+                        .context("get or define timeline attr key")?;
+
+                    self.client
+                        .timeline_metadata([(timeline_key_name, value)])
+                        .await
+                        .context("apply timeline metadata")?;
+                }
+            }
+            Message::NewSpan {
+                id,
+                metadata,
+                mut records,
+            } => {
+                let name = {
+                    // store name for future use
+                    let name = records
+                        .get("name")
+                        .or_else(|| records.get("message"))
+                        .map(|n| format!("{:?}", n))
+                        .unwrap_or_else(|| metadata.name().to_string());
+
+                    self.span_names.insert(id, name.clone());
+
+                    name
+                };
+
+                let mut packed_attrs = Vec::new();
+
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.name".to_string())
+                        .await?,
+                    AttrVal::String(name),
+                ));
+
+                let kind = records
+                    .remove("modality.kind")
+                    .map(tracing_value_to_attr_val)
+                    .unwrap_or_else(|| "span:defined".into());
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.internal.rs.kind".to_string())
+                        .await?,
+                    kind,
+                ));
+
+                let span_id = records
+                    .remove("modality.span_id")
+                    .map(tracing_value_to_attr_val)
+                    .unwrap_or_else(|| BigInt::new_attr_val(u64::from(id) as i128));
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.internal.rs.span_id".to_string())
+                        .await?,
+                    span_id,
+                ));
+
+                self.pack_common_attrs(&mut packed_attrs, metadata, records, tick)
+                    .await?;
+
+                self.client
+                    .event(tick.as_nanos(), packed_attrs)
+                    .await
+                    .context("send packed event")?;
+            }
+            Message::Record { span, records } => {
+                // TODO: span events can't be added to after being sent, impl this once we can use
+                // timelines to represent spans
+
+                let _ = span;
+                let _ = records;
+            }
+            Message::RecordFollowsFrom { span, follows } => {
+                // TODO: span events can't be added to after being sent, impl this once we can use
+                // timelines to represent spans
+
+                let _ = span;
+                let _ = follows;
+            }
+            Message::Event {
+                metadata,
+                mut records,
+            } => {
+                let mut packed_attrs = Vec::new();
+
+                let kind = records
+                    .remove("modality.kind")
+                    .map(tracing_value_to_attr_val)
+                    .unwrap_or_else(|| "event".into());
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.internal.rs.kind".to_string())
+                        .await?,
+                    kind,
+                ));
+
+                self.pack_common_attrs(&mut packed_attrs, metadata, records, tick)
+                    .await?;
+
+                self.client
+                    .event(tick.as_nanos(), packed_attrs)
+                    .await
+                    .context("send packed event")?;
+            }
+            Message::Enter { span } => {
+                let mut packed_attrs = Vec::new();
+
+                {
+                    // get stored span name
+                    let name = self.span_names.get(&span).map(|n| format!("enter: {}", n));
+
+                    if let Some(name) = name {
+                        packed_attrs.push((
+                            self.get_or_create_event_attr_key("event.name".to_string())
+                                .await?,
+                            AttrVal::String(name),
+                        ));
+                    }
+                };
+
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.internal.rs.kind".to_string())
+                        .await?,
+                    AttrVal::String("span:enter".to_string()),
+                ));
+
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.internal.rs.span_id".to_string())
+                        .await?,
+                    BigInt::new_attr_val(u64::from(span).into()),
+                ));
+
+                // only record tick directly during the first ~5.8 centuries this program is running
+                if let Ok(tick) = TryInto::<u64>::try_into(tick.as_nanos()) {
+                    packed_attrs.push((
+                        self.get_or_create_event_attr_key("event.internal.rs.tick".to_string())
+                            .await?,
+                        AttrVal::LogicalTime(LogicalTime::unary(tick)),
+                    ));
+                }
+
+                self.client
+                    .event(tick.as_nanos(), packed_attrs)
+                    .await
+                    .context("send packed event")?;
+            }
+            Message::Exit { span } => {
+                let mut packed_attrs = Vec::new();
+
+                {
+                    // get stored span name
+                    let name = self.span_names.get(&span).map(|n| format!("exit: {}", n));
+
+                    if let Some(name) = name {
+                        packed_attrs.push((
+                            self.get_or_create_event_attr_key("event.name".to_string())
+                                .await?,
+                            AttrVal::String(name),
+                        ));
+                    }
+                };
+
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.internal.rs.kind".to_string())
+                        .await?,
+                    AttrVal::String("span:exit".to_string()),
+                ));
+
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.internal.rs.span_id".to_string())
+                        .await?,
+                    BigInt::new_attr_val(u64::from(span).into()),
+                ));
+
+                // only record tick directly during the first ~5.8 centuries this program is running
+                if let Ok(tick) = TryInto::<u64>::try_into(tick.as_nanos()) {
+                    packed_attrs.push((
+                        self.get_or_create_event_attr_key("event.internal.rs.tick".to_string())
+                            .await?,
+                        AttrVal::LogicalTime(LogicalTime::unary(tick)),
+                    ));
+                }
+
+                self.client
+                    .event(tick.as_nanos(), packed_attrs)
+                    .await
+                    .context("send packed event")?;
+            }
+            Message::Close { span } => {
+                self.span_names.remove(&span);
+            }
+            Message::IdChange { old, new } => {
+                let name = self.span_names.get(&old).cloned();
+                if let Some(name) = name {
+                    self.span_names.insert(new, name);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_or_create_timeline_attr_key(
+        &mut self,
+        key: String,
+    ) -> Result<AttrKey, IngestError> {
+        if let Some(id) = self.timeline_keys.get(&key) {
+            return Ok(*id);
+        }
+
+        let interned_key = self
+            .client
+            .attr_key(key.clone())
+            .await
+            .context("define timeline attr key")?;
+
+        self.timeline_keys.insert(key, interned_key);
+
+        Ok(interned_key)
+    }
+
+    async fn get_or_create_event_attr_key(&mut self, key: String) -> Result<AttrKey, IngestError> {
+        let key = if key.starts_with("event.") {
+            key
+        } else {
+            format!("event.{key}")
+        };
+
+        if let Some(id) = self.event_keys.get(&key) {
+            return Ok(*id);
+        }
+
+        let interned_key = self
+            .client
+            .attr_key(key.clone())
+            .await
+            .context("define event attr key")?;
+
+        self.event_keys.insert(key, interned_key);
+
+        Ok(interned_key)
+    }
+
+    async fn pack_common_attrs<'a>(
+        &mut self,
+        packed_attrs: &mut Vec<(AttrKey, AttrVal)>,
+        metadata: &'a Metadata<'static>,
+        mut records: RecordMap,
+        tick: Duration,
+    ) -> Result<(), IngestError> {
+        let name = records
+            .remove("name")
+            .or_else(|| records.remove("message"))
+            .map(tracing_value_to_attr_val)
+            .unwrap_or_else(|| metadata.name().into());
+        packed_attrs.push((
+            self.get_or_create_event_attr_key("event.name".to_string())
+                .await?,
+            name,
+        ));
+
+        let severity = records
+            .remove("severity")
+            .map(tracing_value_to_attr_val)
+            .unwrap_or_else(|| format!("{}", metadata.level()).to_lowercase().into());
+        packed_attrs.push((
+            self.get_or_create_event_attr_key("event.severity".to_string())
+                .await?,
+            severity,
+        ));
+
+        let module_path = records
+            .remove("source.module")
+            .map(tracing_value_to_attr_val)
+            .or_else(|| metadata.module_path().map(|mp| mp.into()));
+        if let Some(module_path) = module_path {
+            packed_attrs.push((
+                self.get_or_create_event_attr_key("event.source.module".to_string())
+                    .await?,
+                module_path,
+            ));
+        }
+
+        let source_file = records
+            .remove("source.file")
+            .map(tracing_value_to_attr_val)
+            .or_else(|| metadata.file().map(|mp| mp.into()));
+        if let Some(source_file) = source_file {
+            packed_attrs.push((
+                self.get_or_create_event_attr_key("event.source.file".to_string())
+                    .await?,
+                source_file,
+            ));
+        }
+
+        let source_line = records
+            .remove("source.line")
+            .map(tracing_value_to_attr_val)
+            .or_else(|| metadata.line().map(|mp| (mp as i64).into()));
+        if let Some(source_line) = source_line {
+            packed_attrs.push((
+                self.get_or_create_event_attr_key("event.source.line".to_string())
+                    .await?,
+                source_line,
+            ));
+        }
+
+        // only record tick directly during the first ~5.8 centuries this program is running
+        if let Ok(tick) = TryInto::<u64>::try_into(tick.as_nanos()) {
+            packed_attrs.push((
+                self.get_or_create_event_attr_key("event.internal.rs.tick".to_string())
+                    .await?,
+                AttrVal::LogicalTime(LogicalTime::unary(tick)),
+            ));
+        }
+
+        // handle manually to type the AttrVal correctly
+        let remote_timeline_id = records
+            .remove("interaction.remote_timeline_id")
+            .map(tracing_value_to_attr_val);
+        if let Some(attrval) = remote_timeline_id {
+            let remote_timeline_id = if let AttrVal::String(string) = attrval {
+                use std::str::FromStr;
+                if let Ok(uuid) = Uuid::from_str(&string) {
+                    AttrVal::TimelineId(Box::new(uuid.into()))
+                } else {
+                    AttrVal::String(string)
+                }
+            } else {
+                attrval
+            };
+
+            packed_attrs.push((
+                self.get_or_create_event_attr_key("event.interaction.remote_timeline_id".into())
+                    .await?,
+                remote_timeline_id,
+            ));
+        }
+
+        // Manually retype the remote_timestamp
+        let remote_timestamp = records
+            .remove("interaction.remote_timestamp")
+            .map(tracing_value_to_attr_val);
+        if let Some(attrval) = remote_timestamp {
+            let remote_timestamp = match attrval {
+                AttrVal::Integer(i) if i >= 0 => AttrVal::Timestamp(Nanoseconds::from(i as u64)),
+                AttrVal::BigInt(i) if *i >= 0 && *i <= u64::MAX as i128 => {
+                    AttrVal::Timestamp(Nanoseconds::from(*i as u64))
+                }
+                AttrVal::Timestamp(t) => AttrVal::Timestamp(t),
+                x => x,
+            };
+
+            packed_attrs.push((
+                self.get_or_create_event_attr_key("event.interaction.remote_timestamp".into())
+                    .await?,
+                remote_timestamp,
+            ));
+        }
+
+        // Manually retype the local timestamp
+        let local_timestamp = records.remove("timestamp").map(tracing_value_to_attr_val);
+        if let Some(attrval) = local_timestamp {
+            let remote_timestamp = match attrval {
+                AttrVal::Integer(i) if i >= 0 => AttrVal::Timestamp(Nanoseconds::from(i as u64)),
+                AttrVal::BigInt(i) if *i >= 0 && *i <= u64::MAX as i128 => {
+                    AttrVal::Timestamp(Nanoseconds::from(*i as u64))
+                }
+                AttrVal::Timestamp(t) => AttrVal::Timestamp(t),
+                x => x,
+            };
+
+            packed_attrs.push((
+                self.get_or_create_event_attr_key("event.timestamp".into())
+                    .await?,
+                remote_timestamp,
+            ));
+        } else if let Ok(duration_since_epoch) =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)
+        {
+            let duration_since_epoch_in_nanos_res: Result<u64, _> =
+                duration_since_epoch.as_nanos().try_into();
+            if let Ok(duration_since_epoch_in_nanos) = duration_since_epoch_in_nanos_res {
+                packed_attrs.push((
+                    self.get_or_create_event_attr_key("event.timestamp".into())
+                        .await?,
+                    AttrVal::Timestamp(Nanoseconds::from(duration_since_epoch_in_nanos)),
+                ));
+            }
+        }
+
+        // pack any remaining records
+        for (name, value) in records {
+            let attrval = tracing_value_to_attr_val(value);
+
+            let key = if name.starts_with("event.") {
+                name.to_string()
+            } else {
+                format!("event.{}", name.as_str())
+            };
+
+            packed_attrs.push((self.get_or_create_event_attr_key(key).await?, attrval));
+        }
+
+        Ok(())
+    }
+}
+
+// `TracingValue` is `#[nonexhaustive]`, returns `None` if they add a type we don't handle and
+// fail to serialize it as a stringified json value
+fn tracing_value_to_attr_val(value: TracingValue) -> AttrVal {
+    match value {
+        TracingValue::String(s) => AttrVal::String(s),
+        TracingValue::F64(n) => AttrVal::Float(n),
+        TracingValue::I64(n) => AttrVal::Integer(n),
+        TracingValue::U64(n) => BigInt::new_attr_val(n.into()),
+        TracingValue::Bool(b) => AttrVal::Bool(b),
+    }
+}

--- a/tracing-modality/src/layer.rs
+++ b/tracing-modality/src/layer.rs
@@ -1,0 +1,335 @@
+use crate::ingest::TimelineId;
+use crate::options::Options;
+use crate::InitError;
+
+use crate::ingest;
+use crate::ingest::{ModalityIngest, ModalityIngestHandle, WrappedMessage};
+
+use anyhow::Context as _;
+use once_cell::sync::Lazy;
+use std::{
+    cell::Cell,
+    collections::HashMap,
+    fmt::Debug,
+    num::NonZeroU64,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    thread, thread_local,
+    time::Instant,
+};
+use tokio::sync::mpsc::UnboundedSender;
+use tracing_core::{
+    field::Visit,
+    span::{Attributes, Id, Record},
+    Field, Subscriber,
+};
+use tracing_subscriber::{
+    layer::{Context, Layer},
+    prelude::*,
+    registry::{LookupSpan, Registry},
+};
+use uuid::Uuid;
+
+static START: Lazy<Instant> = Lazy::new(Instant::now);
+static NEXT_SPAN_ID: AtomicU64 = AtomicU64::new(1);
+static WARN_LATCH: AtomicBool = AtomicBool::new(false);
+
+/// An ID for spans that we can use directly.
+#[derive(Copy, Clone, Debug)]
+struct LocalSpanId(NonZeroU64);
+
+/// A newtype to store the span's name in itself for later use.
+#[derive(Clone, Debug)]
+struct SpanName(String);
+
+pub struct ModalityLayer {
+    sender: UnboundedSender<WrappedMessage>,
+    ingest_handle: Option<ModalityIngestHandle>,
+}
+
+struct LocalMetadata {
+    thread_timeline: TimelineId,
+}
+
+impl ModalityLayer {
+    thread_local! {
+        static LOCAL_METADATA: Lazy<LocalMetadata> = Lazy::new(|| {
+            LocalMetadata {
+                thread_timeline: ingest::current_timeline(),
+            }
+        });
+        static THREAD_TIMELINE_INITIALIZED: Cell<bool> = Cell::new(false);
+    }
+
+    /// Initialize a new `ModalityLayer`, with default options.
+    pub fn init() -> Result<Self, InitError> {
+        Self::init_with_options(Default::default())
+    }
+
+    /// Initialize a new `ModalityLayer`, with specified options.
+    pub fn init_with_options(mut opts: Options) -> Result<Self, InitError> {
+        let run_id = Uuid::new_v4();
+        opts.add_metadata("run_id", run_id.to_string());
+
+        let ingest = ModalityIngest::connect(opts).context("connect to modality")?;
+        let ingest_handle = ingest.spawn_thread();
+        let sender = ingest_handle.ingest_sender.clone();
+
+        Ok(ModalityLayer {
+            ingest_handle: Some(ingest_handle),
+            sender,
+        })
+    }
+
+    /// Convert this `Layer` into a `Subscriber`by by layering it on a new instace of `tracing`'s
+    /// `Registry`.
+    pub fn into_subscriber(self) -> impl Subscriber {
+        Registry::default().with(self)
+    }
+
+    /// Take the handle to this layer's ingest instance. This can only be taken once.
+    ///
+    /// This handle is primarily for calling [`ModalityIngestHandle::finish()`] at the end of your
+    /// main thread.
+    pub fn take_handle(&mut self) -> Option<ModalityIngestHandle> {
+        self.ingest_handle.take()
+    }
+
+    fn handle_message(&self, message: ingest::Message) {
+        self.ensure_timeline_has_been_initialized();
+        let wrapped_message = ingest::WrappedMessage {
+            message,
+            tick: START.elapsed(),
+            timeline: Self::LOCAL_METADATA.with(|m| m.thread_timeline),
+        };
+
+        if let Err(_e) = self.sender.send(wrapped_message) {
+            // gets a single false across all application threads, atomically replacing with true
+            // only show warning on false, so we only warn once
+            //
+            // ordering doesn't matter, we don't care which thread prints if multiple try
+            let has_warned = WARN_LATCH
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok();
+
+            if !has_warned {
+                eprintln!(
+                    "warning: attempted trace after tracing modality has stopped accepting \
+                     messages, ensure spans from all threads have closed before calling \
+                     `finish()`"
+                );
+            }
+        }
+    }
+
+    fn get_next_span_id(&self) -> LocalSpanId {
+        loop {
+            // ordering of IDs doesn't matter, only uniqueness, use relaxed ordering
+            let id = NEXT_SPAN_ID.fetch_add(1, Ordering::Relaxed);
+            if let Some(id) = NonZeroU64::new(id) {
+                return LocalSpanId(id);
+            }
+        }
+    }
+
+    fn ensure_timeline_has_been_initialized(&self) {
+        if !Self::THREAD_TIMELINE_INITIALIZED.with(|i| i.get()) {
+            Self::THREAD_TIMELINE_INITIALIZED.with(|i| i.set(true));
+
+            let cur = thread::current();
+            let name = cur
+                .name()
+                .map(Into::into)
+                .unwrap_or_else(|| format!("thread-{:?}", cur.id()));
+
+            let message = ingest::Message::NewTimeline { name };
+            let wrapped_message = ingest::WrappedMessage {
+                message,
+                tick: START.elapsed(),
+                timeline: Self::LOCAL_METADATA.with(|m| m.thread_timeline),
+            };
+
+            // ignore failures, exceedingly unlikely here, will get caught in `handle_message`
+            let _ = self.sender.send(wrapped_message);
+        }
+    }
+}
+
+fn get_local_span_id<S>(span: &Id, ctx: &Context<'_, S>) -> LocalSpanId
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    // if either of these fail, it's a bug in `tracing`
+    *ctx.span(span)
+        .expect("get span tracing just told us about")
+        .extensions()
+        .get()
+        .expect("get `LocalSpanId`, should always exist on spans")
+}
+
+impl<S> Layer<S> for ModalityLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn enabled(&self, _metadata: &tracing_core::Metadata<'_>, _ctx: Context<'_, S>) -> bool {
+        // always enabled for all levels
+        true
+    }
+
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let local_id = self.get_next_span_id();
+        ctx.span(id).unwrap().extensions_mut().insert(local_id);
+
+        let mut visitor = RecordMapBuilder::new();
+        attrs.record(&mut visitor);
+        let records = visitor.values();
+        let metadata = attrs.metadata();
+
+        let msg = ingest::Message::NewSpan {
+            id: local_id.0,
+            metadata,
+            records,
+        };
+
+        self.handle_message(msg);
+    }
+
+    fn on_record(&self, span: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let local_id = get_local_span_id(span, &ctx);
+
+        let mut visitor = RecordMapBuilder::new();
+        values.record(&mut visitor);
+
+        let msg = ingest::Message::Record {
+            span: local_id.0,
+            records: visitor.values(),
+        };
+
+        self.handle_message(msg)
+    }
+
+    fn on_follows_from(&self, span: &Id, follows: &Id, ctx: Context<'_, S>) {
+        let local_id = get_local_span_id(span, &ctx);
+        let follows_local_id = get_local_span_id(follows, &ctx);
+
+        let msg = ingest::Message::RecordFollowsFrom {
+            span: local_id.0,
+            follows: follows_local_id.0,
+        };
+
+        self.handle_message(msg)
+    }
+
+    fn on_event(&self, event: &tracing_core::Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = RecordMapBuilder::new();
+        event.record(&mut visitor);
+
+        let msg = ingest::Message::Event {
+            metadata: event.metadata(),
+            records: visitor.values(),
+        };
+
+        self.handle_message(msg)
+    }
+
+    fn on_enter(&self, span: &Id, ctx: Context<'_, S>) {
+        let local_id = get_local_span_id(span, &ctx);
+
+        let msg = ingest::Message::Enter { span: local_id.0 };
+
+        self.handle_message(msg)
+    }
+
+    fn on_exit(&self, span: &Id, ctx: Context<'_, S>) {
+        let local_id = get_local_span_id(span, &ctx);
+
+        let msg = ingest::Message::Exit { span: local_id.0 };
+
+        self.handle_message(msg)
+    }
+
+    fn on_id_change(&self, old: &Id, new: &Id, ctx: Context<'_, S>) {
+        let old_local_id = get_local_span_id(old, &ctx);
+        let new_local_id = self.get_next_span_id();
+        ctx.span(new).unwrap().extensions_mut().insert(new_local_id);
+
+        let msg = ingest::Message::IdChange {
+            old: old_local_id.0,
+            new: new_local_id.0,
+        };
+
+        self.handle_message(msg)
+    }
+
+    fn on_close(&self, span: Id, ctx: Context<'_, S>) {
+        let local_id = get_local_span_id(&span, &ctx);
+
+        let msg = ingest::Message::Close { span: local_id.0 };
+
+        self.handle_message(msg)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum TracingValue {
+    String(String),
+    F64(f64),
+    I64(i64),
+    U64(u64),
+    Bool(bool),
+}
+
+pub(crate) type RecordMap = HashMap<String, TracingValue>;
+
+struct RecordMapBuilder {
+    record_map: RecordMap,
+}
+
+impl RecordMapBuilder {
+    fn values(self) -> RecordMap {
+        self.record_map
+    }
+}
+
+impl RecordMapBuilder {
+    fn new() -> RecordMapBuilder {
+        RecordMapBuilder {
+            record_map: HashMap::new(),
+        }
+    }
+}
+
+impl Visit for RecordMapBuilder {
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        self.record_map.insert(
+            field.name().to_string(),
+            TracingValue::String(format!("{:?}", value)),
+        );
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record_map
+            .insert(field.name().to_string(), TracingValue::F64(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record_map
+            .insert(field.name().to_string(), TracingValue::I64(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record_map
+            .insert(field.name().to_string(), TracingValue::U64(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record_map
+            .insert(field.name().to_string(), TracingValue::Bool(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record_map.insert(
+            field.name().to_string(),
+            TracingValue::String(value.to_string()),
+        );
+    }
+}

--- a/tracing-modality/src/lib.rs
+++ b/tracing-modality/src/lib.rs
@@ -3,24 +3,25 @@
 // (almost) always be called from
 #![allow(clippy::needless_doctest_main)]
 
-use anyhow::Context;
+mod ingest;
+mod layer;
+pub mod options;
+
+pub use ingest::TimelineId;
+pub use layer::ModalityLayer;
+pub use options::Options;
+
+use anyhow::Context as _;
+use ingest::{ConnectError, ModalityIngestHandle};
+use std::fmt::Debug;
 use thiserror::Error;
 use tracing_core::Dispatch;
-use tracing_serde_modality_ingest::ConnectError;
-use tracing_serde_subscriber::TSSubscriber;
-
-pub use tracing_serde_modality_ingest::TimelineId;
-
-/// A `tracing` collector `Layer`.
-pub use tracing_serde_subscriber::TSLayer as ModalityLayer;
-
-pub use tracing_serde_modality_ingest::options::Options;
 
 #[derive(Debug, Error)]
 pub enum InitError {
     /// No auth was provided, set with [`Options::set_auth`]/[`Options::with_auth`] or set the
-    /// `MODALITY_LICENSE KEY` environment variable.
-    #[error("Authentication required, set init option or env var MODALITY_LICENSE_KEY")]
+    /// `MODALITY_AUTH_TOKEN` environment variable.
+    #[error("Authentication required, set init option or env var MODALITY_AUTH_TOKEN")]
     AuthRequired,
 
     /// Auth was provided, but was not accepted by modality.
@@ -35,32 +36,38 @@ pub enum InitError {
 
 /// A global tracer instance for [tracing.rs](https://tracing.rs/) that sends traces via a network
 /// socket to [Modality](https://auxon.io/).
-pub struct TracingModality {}
+pub struct TracingModality {
+    ingest_handle: ModalityIngestHandle,
+}
 
 impl TracingModality {
     /// Initialize with default options and set as the global default tracer.
     pub fn init() -> Result<Self, InitError> {
-        let disp = Dispatch::new(TSSubscriber::new());
-        tracing::dispatcher::set_global_default(disp).unwrap();
-
-        TSSubscriber::connect().context("connect to modality")?;
-
-        Ok(Self {})
+        Self::init_with_options(Default::default())
     }
 
     /// Initialize with the provided options and set as the global default tracer.
-    pub fn init_with_options(opt: Options) -> Result<Self, InitError> {
-        let disp = Dispatch::new(TSSubscriber::new_with_options(opt));
+    pub fn init_with_options(opts: Options) -> Result<Self, InitError> {
+        let mut layer =
+            ModalityLayer::init_with_options(opts).context("initialize ModalityLayer")?;
+        let ingest_handle = layer
+            .take_handle()
+            .expect("take handle on brand new layer somehow failed");
+
+        let disp = Dispatch::new(layer.into_subscriber());
         tracing::dispatcher::set_global_default(disp).unwrap();
 
-        TSSubscriber::connect().context("connect to modality")?;
+        Ok(Self { ingest_handle })
+    }
 
-        Ok(Self {})
+    /// Stop accepting new trace events, flush all existing events, and stop ingest thread.
+    pub fn finish(self) {
+        self.ingest_handle.finish();
     }
 }
 
 /// Retrieve the current local timeline ID. Useful for for sending alongside data and a custom nonce
 /// for recording timeline interactions on remote timelines.
 pub fn timeline_id() -> TimelineId {
-    tracing_serde_subscriber::timeline_id()
+    ingest::current_timeline()
 }

--- a/tracing-modality/src/options.rs
+++ b/tracing-modality/src/options.rs
@@ -1,0 +1,109 @@
+use modality_ingest_client::types::AttrVal;
+use std::net::SocketAddr;
+
+/// Initialization options.
+#[derive(Clone)]
+pub struct Options {
+    pub(crate) auth: Option<Vec<u8>>,
+    pub(crate) metadata: Vec<(String, AttrVal)>,
+    pub(crate) server_addr: SocketAddr,
+}
+
+impl Options {
+    pub fn new() -> Options {
+        let auth = Self::resolve_auth_token();
+        let server_addr = ([127, 0, 0, 1], 14182).into();
+        Options {
+            auth,
+            metadata: Vec::new(),
+            server_addr,
+        }
+    }
+
+    fn resolve_auth_token() -> Option<Vec<u8>> {
+        if let Some(from_env) = std::env::var("MODALITY_AUTH_TOKEN")
+            .ok()
+            .and_then(|t| hex::decode(t).ok())
+        {
+            return Some(from_env);
+        }
+
+        dirs::config_dir()
+            .and_then(|config| {
+                let file_path = config.join("modality_cli").join(".user_auth_token");
+                std::fs::read_to_string(file_path).ok()
+            })
+            .and_then(|t| hex::decode(t.trim()).ok())
+    }
+
+    /// Set an auth token to be provided to modality. Tokens should be a hex stringish value.
+    pub fn set_auth<S: AsRef<[u8]>>(&mut self, auth: S) {
+        self.auth = hex::decode(auth).ok();
+    }
+    /// A chainable version of [set_auth](Self::set_auth).
+    pub fn with_auth<S: AsRef<[u8]>>(mut self, auth: S) -> Self {
+        self.auth = hex::decode(auth).ok();
+        self
+    }
+
+    /// Set the name for the root timeline. By default this will be the name of the main thread as
+    /// provided by the OS.
+    pub fn set_name<S: AsRef<str>>(&mut self, name: S) {
+        self.metadata.push((
+            "timeline.name".to_string(),
+            AttrVal::String(name.as_ref().to_string()),
+        ));
+    }
+    /// A chainable version of [set_name](Self::set_name).
+    pub fn with_name<S: AsRef<str>>(mut self, name: S) -> Self {
+        self.metadata.push((
+            "timeline.name".to_string(),
+            AttrVal::String(name.as_ref().to_string()),
+        ));
+        self
+    }
+
+    /// Add arbitrary metadata to the root timeline.
+    ///
+    /// This can be called multiple times.
+    pub fn add_metadata<K: AsRef<str>, V: Into<AttrVal>>(&mut self, key: K, value: V) {
+        let key = key.as_ref();
+        let key = if key.starts_with("timeline.") {
+            key.to_string()
+        } else {
+            format!("timeline.{}", key)
+        };
+
+        self.metadata.push((key, value.into()));
+    }
+    /// A chainable version of [add_metadata](Self::add_metadata).
+    pub fn with_metadata<K: AsRef<str>, V: Into<AttrVal>>(mut self, key: K, value: V) -> Self {
+        let key = key.as_ref();
+        let key = if key.starts_with("timeline.") {
+            key.to_string()
+        } else {
+            format!("timeline.{}", key)
+        };
+
+        self.metadata.push((key, value.into()));
+        self
+    }
+
+    /// Set the address of modalityd or a modality reflector where trace data should be sent.
+    ///
+    /// Defaults to `localhost:default_port`
+    pub fn set_server_address(&mut self, addr: SocketAddr) {
+        self.server_addr = addr;
+    }
+    /// A chainable version of [set_server_address](Self::set_server_address).
+    pub fn with_server_address(mut self, addr: SocketAddr) -> Self {
+        self.server_addr = addr;
+        self
+    }
+}
+
+impl Default for Options {
+    fn default() -> Options {
+        Options::new()
+    }
+}


### PR DESCRIPTION
This allows use from tokio applications & other async runtimes.

This also drops the use of the tracing-serde-* crates and moves that
functionality within itself. These changes would have required
deviating even further from upstream in incompatible ways. This also
should improve performance because we're going to be cloning fewer
things that we don't end up even using.

Breaking Changes

This adds a `finish` function to `TracingModality` that must be called
before the main thread exits to ensure that all tracing messages have
been flushed to Modality. (This is the same thing that open telemetry
does.)

This also removes the `ModalitySubscriber` type that was previously
impossible to construct anyway and replaces it with
`ModalityLayer::into_subscriber()`.

------

`tracing-modality/src/layer.rs` is largely `tracing-serde-subscriber` and `tracing-modality/src/ingest.rs` is largely `tracing-serde-modality-ingest`, except stripped down and specialized for handling exactly the information that we need here.