### PR TITLE
Allow user to provide timeline callback

### DIFF
--- a/tracing-modality/src/async/layer.rs
+++ b/tracing-modality/src/async/layer.rs
@@ -1,13 +1,10 @@
 use crate::common::options::Options;
-use crate::InitError;
+use crate::{InitError, TIMELINE_IDENTIFIER};
 
-use crate::common::layer::{LayerHandler, LocalMetadata};
-use crate::ingest;
+use crate::common::layer::LayerHandler;
 use crate::ingest::{ModalityIngest, ModalityIngestTaskHandle, WrappedMessage};
 
 use anyhow::Context as _;
-use once_cell::sync::Lazy;
-use std::{cell::Cell, thread::LocalKey, thread_local};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tracing_core::Subscriber;
 use tracing_subscriber::{layer::SubscriberExt, Registry};
@@ -22,15 +19,6 @@ pub struct ModalityLayer {
 }
 
 impl ModalityLayer {
-    thread_local! {
-        static LOCAL_METADATA: Lazy<LocalMetadata> = Lazy::new(|| {
-            LocalMetadata {
-                thread_timeline: ingest::current_timeline(),
-            }
-        });
-        static THREAD_TIMELINE_INITIALIZED: Cell<bool> = Cell::new(false);
-    }
-
     /// Initialize a new `ModalityLayer`, with default options.
     pub async fn init() -> Result<(Self, ModalityIngestTaskHandle), InitError> {
         Self::init_with_options(Default::default()).await
@@ -42,6 +30,10 @@ impl ModalityLayer {
     ) -> Result<(Self, ModalityIngestTaskHandle), InitError> {
         let run_id = Uuid::new_v4();
         opts.add_metadata("run_id", run_id.to_string());
+
+        TIMELINE_IDENTIFIER
+            .set(opts.timeline_identifier)
+            .map_err(|_| InitError::InitializedTwice)?;
 
         let ingest = ModalityIngest::async_connect(opts)
             .await
@@ -62,13 +54,5 @@ impl ModalityLayer {
 impl LayerHandler for ModalityLayer {
     fn send(&self, msg: WrappedMessage) -> Result<(), mpsc::error::SendError<WrappedMessage>> {
         self.sender.send(msg)
-    }
-
-    fn local_metadata(&self) -> &'static LocalKey<Lazy<LocalMetadata>> {
-        &Self::LOCAL_METADATA
-    }
-
-    fn thread_timeline_initialized(&self) -> &'static LocalKey<Cell<bool>> {
-        &Self::THREAD_TIMELINE_INITIALIZED
     }
 }

--- a/tracing-modality/src/blocking/layer.rs
+++ b/tracing-modality/src/blocking/layer.rs
@@ -1,13 +1,10 @@
 use crate::common::options::Options;
 use crate::InitError;
 
-use crate::common::layer::{LayerHandler, LocalMetadata};
-use crate::ingest;
+use crate::common::layer::LayerHandler;
 use crate::ingest::{ModalityIngest, ModalityIngestThreadHandle, WrappedMessage};
 
 use anyhow::Context as _;
-use once_cell::sync::Lazy;
-use std::{cell::Cell, thread::LocalKey, thread_local};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tracing_core::Subscriber;
 use tracing_subscriber::{layer::SubscriberExt, Registry};
@@ -22,15 +19,6 @@ pub struct ModalityLayer {
 }
 
 impl ModalityLayer {
-    thread_local! {
-        static LOCAL_METADATA: Lazy<LocalMetadata> = Lazy::new(|| {
-            LocalMetadata {
-                thread_timeline: ingest::current_timeline(),
-            }
-        });
-        static THREAD_TIMELINE_INITIALIZED: Cell<bool> = Cell::new(false);
-    }
-
     /// Initialize a new `ModalityLayer`, with default options.
     pub fn init() -> Result<(Self, ModalityIngestThreadHandle), InitError> {
         Self::init_with_options(Default::default())
@@ -60,13 +48,5 @@ impl ModalityLayer {
 impl LayerHandler for ModalityLayer {
     fn send(&self, msg: WrappedMessage) -> Result<(), mpsc::error::SendError<WrappedMessage>> {
         self.sender.send(msg)
-    }
-
-    fn local_metadata(&self) -> &'static LocalKey<Lazy<LocalMetadata>> {
-        &Self::LOCAL_METADATA
-    }
-
-    fn thread_timeline_initialized(&self) -> &'static LocalKey<Cell<bool>> {
-        &Self::THREAD_TIMELINE_INITIALIZED
     }
 }

--- a/tracing-modality/src/common/mod.rs
+++ b/tracing-modality/src/common/mod.rs
@@ -5,8 +5,18 @@ pub(crate) mod options;
 #[cfg(doc)]
 use crate::Options;
 use ingest::{ConnectError, TimelineId};
+use once_cell::sync::OnceCell;
 use std::fmt::Debug;
 use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct TimelineInfo {
+    // TODO: Can we make this a &'static str to avoid allocations? Maybe a Cow<str>?
+    pub name: String,
+    pub id: TimelineId,
+}
+
+pub(crate) static TIMELINE_IDENTIFIER: OnceCell<fn() -> TimelineInfo> = OnceCell::new();
 
 #[derive(Debug, Error)]
 pub enum InitError {
@@ -20,6 +30,10 @@ pub enum InitError {
     #[error(transparent)]
     AuthFailed(ConnectError),
 
+    /// Modality was initialized twice
+    #[error("Modality was initialized twice")]
+    InitializedTwice,
+
     /// Errors that it is assumed there is no way to handle without human intervention, meant for
     /// consumers to just print and carry on or panic.
     #[error(transparent)]
@@ -29,5 +43,5 @@ pub enum InitError {
 /// Retrieve the current local timeline ID. Useful for for sending alongside data and a custom nonce
 /// for recording timeline interactions on remote timelines.
 pub fn timeline_id() -> TimelineId {
-    ingest::current_timeline()
+    ingest::thread_timeline().id
 }

--- a/tracing-modality/src/common/options.rs
+++ b/tracing-modality/src/common/options.rs
@@ -1,3 +1,4 @@
+use crate::{common::ingest::thread_timeline, TimelineInfo};
 use modality_ingest_client::types::AttrVal;
 use std::net::SocketAddr;
 
@@ -7,6 +8,7 @@ pub struct Options {
     pub(crate) auth: Option<Vec<u8>>,
     pub(crate) metadata: Vec<(String, AttrVal)>,
     pub(crate) server_addr: SocketAddr,
+    pub(crate) timeline_identifier: fn() -> TimelineInfo,
 }
 
 impl Options {
@@ -17,6 +19,7 @@ impl Options {
             auth,
             metadata: Vec::new(),
             server_addr,
+            timeline_identifier: thread_timeline,
         }
     }
 
@@ -34,6 +37,10 @@ impl Options {
                 std::fs::read_to_string(file_path).ok()
             })
             .and_then(|t| hex::decode(t.trim()).ok())
+    }
+
+    pub fn set_timeline_identifier(&mut self, identifier: fn() -> TimelineInfo) {
+        self.timeline_identifier = identifier;
     }
 
     /// Set an auth token to be provided to modality. Tokens should be a hex stringish value.


### PR DESCRIPTION
This introduces the ability for the user to report the current timeline information (a UUID/TimelineId and name string).

This somewhat significantly reworks how current timeline information is tracked, which removes some thread locals, and introduces some globals.

Marked as WIP as I am still working on getting this going in mnemOS (with Tokio and Maitake task IDs) to validate it works as expected. Early feedback is welcome.